### PR TITLE
feat: add option to mark plausible is self-hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ _NOTE: By default, this plugin only generates output when run in production mode
 
 ### Options
 
-| Option         | Explanation                                            |
-| -------------- | ------------------------------------------------------ |
-| `domain`       | The domain configured in Plausible (required)          |
-| `customDomain` | Custom domain (if configured in Plausible's dashboard) |
-| `excludePaths` | Array of pathnames where page views will not be sent   |
+| Option         | Explanation                                                                               |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| `domain`       | The domain configured in Plausible (required)                                             |
+| `customDomain` | Custom domain (if configured in Plausible's dashboard)                                    |
+| `excludePaths` | Array of pathnames where page views will not be sent                                      |
+| `isSelfHosted` | If you [self-host](https://docs.plausible.io/self-hosting) Plausible. Defaults to `false` |
 
 ### Pageview events
 

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,14 +1,16 @@
 import React from 'react';
 
 const getOptions = (pluginOptions) => {
+  const isSelfHosted = pluginOptions.isSelfHosted || false;
   const plausibleDomain = pluginOptions.customDomain || 'plausible.io';
   const scriptURI =
-    plausibleDomain === 'plausible.io' ? '/js/plausible.js' : '/js/index.js';
+    (plausibleDomain === 'plausible.io' || isSelfHosted) ? '/js/plausible.js' : '/js/index.js';
   const domain = pluginOptions.domain;
   const excludePaths = pluginOptions.excludePaths || [];
   const trackAcquisition = pluginOptions.trackAcquisition || false;
 
   return {
+    isSelfHosted,
     plausibleDomain,
     scriptURI,
     domain,


### PR DESCRIPTION
As mentioned in  #49 , if you self host Plausible it defaults to `/js/plausible.js` instead of `/js/index.js` so I thought we could add an option for it.

The option `isSelfHosted` defaults to `false`, so it would not break any existing sites using the plugin. 

Let me know what you think and if this is useful! 😄 