### PR TITLE
Fixed scriptURI of self-hosted plausible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-plausible",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-plausible",
   "description": "A Gatsby plugin for adding Plausible analytics to your Gatsby site",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "Curtis Cummings <curtis@pixelplicity.com>",
   "license": "MIT",
   "repository": "pixelplicity/gatsby-plugin-plausible",

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -2,8 +2,7 @@ import React from 'react';
 
 const getOptions = (pluginOptions) => {
   const plausibleDomain = pluginOptions.customDomain || 'plausible.io';
-  const scriptURI =
-    plausibleDomain === 'plausible.io' ? '/js/plausible.js' : '/js/index.js';
+  const scriptURI = '/js/plausible.js';
   const domain = pluginOptions.domain;
   const excludePaths = pluginOptions.excludePaths || [];
   const trackAcquisition = pluginOptions.trackAcquisition || false;


### PR DESCRIPTION
Changed `scriptURI`: latest version of plausible uses `/js/plausible.js` for self-hosted versions too. 

I installed the latest version of plausible's docker-compose and the js snippet looks like the following:

```
<script async defer data-domain="<DOMAIN>" src="https://<PLAUSIBLE-DOMAIN>/js/plausible.js"></script>
```

