### PR TITLE
Add support for outbound link click tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ _NOTE: By default, this plugin only generates output when run in production mode
 
 ### Options
 
-| Option         | Explanation                                            |
-| -------------- | ------------------------------------------------------ |
-| `domain`       | The domain configured in Plausible (required)          |
-| `customDomain` | Custom domain (if configured in Plausible's dashboard) |
-| `excludePaths` | Array of pathnames where page views will not be sent   |
+| Option               | Explanation                                                                                                                                                            |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `domain`             | The domain configured in Plausible (required)                                                                                                                          |
+| `customDomain`       | Custom domain (if configured in Plausible's dashboard)                                                                                                                 |
+| `excludePaths`       | Array of pathnames where page views will not be sent                                                                                                                   |
+| `trackOutboundLinks` | If [outbound links](https://docs.plausible.io/outbound-link-click-tracking/) should be tracked (needs custom event goal in Plausible's dashboard, defaults to `false`) |
 
 ### Pageview events
 

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -2,8 +2,13 @@ import React from 'react';
 
 const getOptions = (pluginOptions) => {
   const plausibleDomain = pluginOptions.customDomain || 'plausible.io';
+  const scriptExtension = pluginOptions.trackOutboundLinks
+    ? '.outbound-links.js'
+    : '.js';
   const scriptURI =
-    plausibleDomain === 'plausible.io' ? '/js/plausible.js' : '/js/index.js';
+    plausibleDomain === 'plausible.io'
+      ? '/js/plausible' + scriptExtension
+      : '/js/index' + scriptExtension;
   const domain = pluginOptions.domain;
   const excludePaths = pluginOptions.excludePaths || [];
   const trackAcquisition = pluginOptions.trackAcquisition || false;


### PR DESCRIPTION
If outbound link click tracking should be enabled in Plausible, a different script must be included. I have added an option for that in the configuration which defaults to `false`, so it won't break existing installations.

Let me know if you need anything else about it.