### PR TITLE
fix: add option for custom script URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ _NOTE: By default, this plugin only generates output when run in production mode
 
 ### Options
 
-| Option         | Explanation                                            |
-| -------------- | ------------------------------------------------------ |
-| `domain`       | The domain configured in Plausible (required)          |
-| `customDomain` | Custom domain (if configured in Plausible's dashboard) |
-| `excludePaths` | Array of pathnames where page views will not be sent   |
+| Option            | Explanation                                            |
+| ----------------- | ------------------------------------------------------ |
+| `domain`          | The domain configured in Plausible (required)          |
+| `customDomain`    | Custom domain (if configured in Plausible's dashboard) |
+| `customScriptURI` | Custom script URI (defaults to "/js/plausible.js")     |
+| `excludePaths`    | Array of pathnames where page views will not be sent   |
 
 ### Pageview events
 

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -2,8 +2,7 @@ import React from 'react';
 
 const getOptions = (pluginOptions) => {
   const plausibleDomain = pluginOptions.customDomain || 'plausible.io';
-  const scriptURI =
-    plausibleDomain === 'plausible.io' ? '/js/plausible.js' : '/js/index.js';
+  const scriptURI = pluginOptions.customScriptURI || '/js/plausible.js';
   const domain = pluginOptions.domain;
   const excludePaths = pluginOptions.excludePaths || [];
   const trackAcquisition = pluginOptions.trackAcquisition || false;


### PR DESCRIPTION
When self-hosting the script is no longer placed under `js/index.js` but `js/plausible.js`. 

This adds the option to define a custom URI for the script.